### PR TITLE
Turn on adoc-mode automatically

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2899,6 +2899,11 @@ Turning on Adoc mode runs the normal hook `adoc-mode-hook'."
   (easy-menu-add adoc-mode-menu)
   (run-hooks 'adoc-mode-hook))
 
+;;;###autoload
+(progn
+  (add-to-list 'auto-mode-alist '("\\.adoc\\'" . adoc-mode))
+  (add-to-list 'auto-mode-alist '("\\.asciidoc\\'" . adoc-mode)))
+
 
 ;;;; non-definitions evaluated during load  
 (adoc-calc)


### PR DESCRIPTION
This commit ensures that users who have installed `adoc-mode` from a Marmalade or MELPA package will be able to automatically turn on `adoc-mode` when visiting `asciidoc` or `adoc` fies without explicitly requiring the library first.
