### PR TITLE
Use mode-* to set var require-final-newline

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -3016,7 +3016,7 @@ Turning on Adoc mode runs the normal hook `adoc-mode-hook'."
   
   ;; misc
   (set (make-local-variable 'page-delimiter) "^<<<+$")
-  (set (make-local-variable 'require-final-newline) t)
+  (set (make-local-variable 'require-final-newline) mode-require-final-newline)
   (set (make-local-variable 'parse-sexp-lookup-properties) t)
   
   ;; it's the user's decision whether he wants to set imenu-sort-function to


### PR DESCRIPTION
This follows the documentation of `mode-require-final-newline` that says the local value of `require-final-newline` should be set to the value of the former (`mode-require-final-newline`). Another important thing to mention is that this will fix the issue / warning that occurs when using adoc-mode with ethan-wspace. This shouldn't change the behavior for any other users because the default value of `mode-require-final-newline` is true anyway.
